### PR TITLE
Fix: resolve 15px bottom overflow in course cards

### DIFF
--- a/lib/screens/courses/courses_screen.dart
+++ b/lib/screens/courses/courses_screen.dart
@@ -72,9 +72,9 @@ class CoursesScreen extends StatelessWidget {
                   crossAxisCount: AppScreenUtil.isMobile(context)
                       ? 2
                       : AppScreenUtil.adaptiveGridCount(context),
-                  childAspectRatio: AppScreenUtil.isMobile(context)
-                      ? 0.82
-                      : 1.05,
+                  mainAxisExtent: AppScreenUtil.isMobile(context)
+                      ? 260.h
+                      : 280.h,
                   crossAxisSpacing: 10.w,
                   mainAxisSpacing: 10.h,
                 ),


### PR DESCRIPTION
Fixes #4 
This PR resolves a UI bug where the course cards on the `CoursesScreen` were experiencing a 15px vertical overflow at the bottom of the grid layout.


https://github.com/user-attachments/assets/0b72f8f7-d13c-4464-9655-ceddaf2d0422



## Changes Made
- Replaced the rigid `childAspectRatio` property with a fixed `mainAxisExtent` on the `SliverGridDelegate`. 
- By enforcing a concrete height (`260.h` for mobile, `280.h` for other sizes) instead of a width-dependent ratio, the course cards maintain an expected consistent height across all device dimensions, completely preventing the overflow.