### PR TITLE
[NSoC'26] fix: Change inline validators with AppValidators in auth screens

### DIFF
--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -12,6 +12,7 @@ import '../../constants/router/app_routes_list.dart';
 import '../../providers/auth_form_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../shared/utils/screen_util.dart';
+import '../../shared/validators/app_validators.dart';
 
 class LoginScreen extends StatelessWidget {
   const LoginScreen({super.key});
@@ -73,15 +74,7 @@ class LoginScreen extends StatelessWidget {
                             decoration: const InputDecoration(
                               labelText: 'Email',
                             ),
-                            validator: (String? value) {
-                              if (value == null || value.trim().isEmpty) {
-                                return 'Email is required';
-                              }
-                              if (!value.contains('@')) {
-                                return 'Enter a valid email';
-                              }
-                              return null;
-                            },
+                            validator: AppValidators.email,
                           ),
                           SizedBox(height: 12.h),
                           TextFormField(
@@ -98,15 +91,7 @@ class LoginScreen extends StatelessWidget {
                                 ),
                               ),
                             ),
-                            validator: (String? value) {
-                              if (value == null || value.isEmpty) {
-                                return 'Password is required';
-                              }
-                              if (value.length < 6) {
-                                return 'Minimum 6 characters';
-                              }
-                              return null;
-                            },
+                            validator: AppValidators.password,
                           ),
                           SizedBox(height: 10.h),
                           Row(

--- a/lib/screens/auth/signup_screen.dart
+++ b/lib/screens/auth/signup_screen.dart
@@ -11,6 +11,7 @@ import '../../constants/router/app_routes_list.dart';
 import '../../providers/auth_form_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../shared/utils/screen_util.dart';
+import '../../shared/validators/app_validators.dart';
 
 class SignUpScreen extends StatelessWidget {
   const SignUpScreen({super.key});
@@ -92,15 +93,7 @@ class SignUpScreen extends StatelessWidget {
                             decoration: const InputDecoration(
                               labelText: 'Email',
                             ),
-                            validator: (String? value) {
-                              if (value == null || value.trim().isEmpty) {
-                                return 'Email is required';
-                              }
-                              if (!value.contains('@')) {
-                                return 'Enter a valid email';
-                              }
-                              return null;
-                            },
+                            validator: AppValidators.email,
                           ),
                           SizedBox(height: 12.h),
                           TextFormField(
@@ -117,15 +110,7 @@ class SignUpScreen extends StatelessWidget {
                                 ),
                               ),
                             ),
-                            validator: (String? value) {
-                              if (value == null || value.isEmpty) {
-                                return 'Password is required';
-                              }
-                              if (value.length < 6) {
-                                return 'Minimum 6 characters';
-                              }
-                              return null;
-                            },
+                            validator: AppValidators.password,
                           ),
                           SizedBox(height: 12.h),
                           TextFormField(
@@ -142,13 +127,10 @@ class SignUpScreen extends StatelessWidget {
                                 ),
                               ),
                             ),
-                            validator: (String? value) {
-                              if (value !=
-                                  formProvider.passwordController.text) {
-                                return 'Passwords do not match';
-                              }
-                              return null;
-                            },
+                            validator: (String? value) =>AppValidators.confirmPassword(
+                                    value,
+                                    formProvider.passwordController.text,
+                            ),
                           ),
                           SizedBox(height: 10.h),
                           Row(


### PR DESCRIPTION
# 13

## 📌 Description
Replaced weak inline validators in login_screen.dart and signup_screen.dart with the existing AppValidators class from lib/shared/validators/app_validators.dart.
The inline validators were inconsistent and weaker than the shared validator that was already present in the codebase but unused.

## 🔗 Related Issue
Fixes #12 

## 🚀 Type of Change
- [✅] Bug Fix  
- [✅] Enhancement  


## 🧪 Testing
- Tested email field with invalid inputs like "test@", "abc", "a@x"
- Verified proper error messages appear for weak passwords under 8 characters
- Verified passwords without letters or numbers are rejected.
- Tested confirm password mismatch on signup screen
- All valid inputs pass through correctly



## ✅ Checklist
- [✅] Code follows guidelines  
- [✅] Tested properly   
- [ ] Docs updated
- [✅] PR title includes **NSoC'26**

